### PR TITLE
Add simple usage example

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,0 +1,63 @@
+"""Simple usage example of kafka-logging-handler."""
+
+import logging
+import os
+import sys
+import time
+
+from kafka_logger.handlers import KafkaLoggingHandler
+
+REQUIRED_ENV_VARS = ['KAFKA_SERVER', 'KAFKA_CERT', 'KAFKA_TOPIC']
+
+
+def main():
+    """Setup logger and test logging."""
+    # validate that Kafka configuration is available
+    assert all([(key in os.environ) for key in REQUIRED_ENV_VARS])
+
+    logger = logging.getLogger("test.logger")
+    logger.propagate = False
+    log_level = logging.DEBUG
+
+    log_format = logging.Formatter(
+        '%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+        '%Y-%m-%dT%H:%M:%S')
+
+    # create handler to show logs at stdout
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(log_level)
+    stdout_handler.setFormatter(log_format)
+    logger.addHandler(stdout_handler)
+
+    # create Kafka logging handler
+    kafka_handler = KafkaLoggingHandler(
+        os.environ['KAFKA_SERVER'],
+        os.environ['KAFKA_TOPIC'],
+        security_protocol='SSL',
+        ssl_cafile=os.environ['KAFKA_CERT'],
+        # you can configure how often logger will send logs to Kafka
+        # flush_buffer_size=3,  # uncomment to see that it works slower
+        # flush_interval=3.0,  # interval in seconds
+        unhandled_exception_logger=logger,
+        # you can include arbitrary fields to all produced logs
+        additional_fields={
+            "service": "test_service"
+        }
+    )
+    kafka_handler.setFormatter(log_format)
+    logger.addHandler(kafka_handler)
+
+    logger.setLevel(log_level)
+
+    # test logging
+    logger.debug("Test debug level logs")
+    for idx in range(6):
+        logger.info("Test log #%d", idx)
+        time.sleep(0.5)
+
+    # log unhandled top-level exception logging
+    raise Exception('No try/except block here')
+
+
+if __name__ == '__main__':
+    main()

--- a/kafka_logger/handlers.py
+++ b/kafka_logger/handlers.py
@@ -32,6 +32,7 @@ class KafkaLoggingHandler(logging.Handler):
             logger that will be used to log uhandled top-level exception
 
     """
+
     __LOGGING_FILTER_FIELDS = ['msecs',
                                'relativeCreated',
                                'levelno',
@@ -85,8 +86,10 @@ class KafkaLoggingHandler(logging.Handler):
         self.flush_interval = flush_interval
         self.timer = None
         self.additional_fields = additional_fields.copy()
-        self.additional_fields.update({'host': socket.gethostname(),
-                                       'host_ip': socket.gethostbyname(socket.gethostname())})
+        self.additional_fields.update({
+            'host': socket.gethostname(),
+            'host_ip': socket.gethostbyname(socket.gethostname())
+        })
 
         if kafka_producer_args is None:
             kafka_producer_args = {}

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 #           https://github.com/tox-dev/tox/blob/master/tox.ini
 
 [vars]
-SOURCE = kafka_logger
+SOURCE = kafka_logger examples
 TEST_DIR = tests 
 
 [tox]
@@ -46,4 +46,5 @@ import-order-style = google
 
 [testenv:mypy]
 deps = mypy
+basepython = python3
 commands = mypy --ignore-missing-imports {[vars]SOURCE}


### PR DESCRIPTION
Example code uses Kafka configuration from env variables.
Additionally:
- fixed flake8 warning in handler.py
- added examples directory in tox.ini
- switched mypy tox config for python3