### PR TITLE
Fix traceback of unhandled top-level exceptions

### DIFF
--- a/kafka_logger/handlers.py
+++ b/kafka_logger/handlers.py
@@ -178,20 +178,19 @@ class KafkaLoggingHandler(logging.Handler):
             self.flush()
         self.producer.close()
 
-    def unhandled_exception(self, _, exception, __):
+    def unhandled_exception(self, exctype, exception, traceback):
         """
         Log top-level exception to the provided logger.
 
         Args:
+            exctype (type): type of the exception
             exception (Exception): exception object from excepthook
-
+            traceback (traceback): traceback object
         """
         if self.unhandled_exception_logger is not None:
-            try:
-                raise exception
-            except Exception:
-                self.unhandled_exception_logger.exception(
-                    "Unhandled top-level exception")
+            self.unhandled_exception_logger.exception(
+                "Unhandled top-level exception",
+                exc_info=(exctype, exception, traceback, ))
 
     def close(self):
         """Close the handler."""


### PR DESCRIPTION
There is no need to raise the exception to log it. Exception log call can receive `exc_info` parameter.
Before (incorrect traceback):
```
Traceback (most recent call last):
  File "/home/mbirger/workspace/kafka-logging-handler/kafka_logger/handlers.py", line 194, in unhandled_exception
    raise exception
  File "examples/simple.py", line 63, in <module>
    main()
  File "examples/simple.py", line 59, in main
    raise Exception('No try/except block here')
Exception: No try/except block here
```

After:
```
Traceback (most recent call last):
  File "examples/simple.py", line 63, in <module>
    main()
  File "examples/simple.py", line 59, in main
    raise Exception('No try/except block here')
Exception: No try/except block here

```