### PR TITLE
Fix logging of non-serializable object (Python 2)

### DIFF
--- a/kafka_logger/handlers.py
+++ b/kafka_logger/handlers.py
@@ -160,7 +160,7 @@ class KafkaLoggingHandler(logging.Handler):
                     # Elasticsearch supports number datatypes
                     # but it is not 1:1 - logging "inf" float
                     # causes _jsonparsefailure error in ELK
-                    value = tuple(arg.__repr__() for arg in value)
+                    value = tuple(repr(arg) for arg in value)
                 rec[key] = "" if value is None else value
 
         return rec


### PR DESCRIPTION
Direct call of __repr__ method causes Python failure in Python 2.
Actual code works only in Python 3.
repr() call works in both Python 2/3.