### PR TITLE
Elk timestamp

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -39,6 +39,10 @@ def main():
         # flush_buffer_size=3,  # uncomment to see that it works slower
         # flush_interval=3.0,  # interval in seconds
         unhandled_exception_logger=logger,
+        kafka_producer_args={
+            'api_version_auto_timeout_ms': 1000000,
+            'request_timeout_ms': 1000000,
+        },
         # you can include arbitrary fields to all produced logs
         additional_fields={
             "service": "test_service"
@@ -51,7 +55,7 @@ def main():
 
     # test logging
     logger.debug("Test debug level logs")
-    for idx in range(6):
+    for idx in range(3):
         logger.info("Test log #%d", idx)
         time.sleep(0.5)
 

--- a/kafka_logger/handlers.py
+++ b/kafka_logger/handlers.py
@@ -9,6 +9,7 @@ import socket
 import sys
 from threading import Lock, Thread, Timer
 import time
+import datetime
 
 from kafka import KafkaProducer  # pylint: disable=import-error
 
@@ -172,7 +173,14 @@ class KafkaLoggingHandler(logging.Handler):
                     # if there is no formatting in the logging call
                     value = str(value)
                 rec[key] = "" if value is None else value
-
+            if key == 'created':
+                # inspired by: cmanaha/python-elasticsearch-logger
+                created_date = \
+                    datetime.datetime.utcfromtimestamp(record.created)
+                rec['timestamp'] = \
+                    "{0!s}.{1:03d}Z".format(
+                        created_date.strftime('%Y-%m-%dT%H:%M:%S'),
+                        int(created_date.microsecond / 1000))
         # apply preprocessor(s)
         for preprocessor in self.log_preprocess:
             rec = preprocessor(rec)


### PR DESCRIPTION
Add original log timestamp into log records.

"timestamp" field is included in log records.
ELK automatically parses the field as a 'date' type.
Changing time field in Kibana UI required index pattern recreation.
