### PR TITLE
Dont redefine sys.excepthook if no logger provided

### DIFF
--- a/kafka_logger/handlers.py
+++ b/kafka_logger/handlers.py
@@ -123,7 +123,8 @@ class KafkaLoggingHandler(logging.Handler):
         # exit hooks work only in main process
         # termination of child processes uses os.exit() and ignore any hooks
         atexit.register(self.at_exit)
-        sys.excepthook = self.unhandled_exception
+        if self.unhandled_exception is not None:
+            sys.excepthook = self.unhandled_exception
 
         # multiprocessing support
         self.main_process_pid = os.getpid()

--- a/kafka_logger/handlers.py
+++ b/kafka_logger/handlers.py
@@ -123,7 +123,9 @@ class KafkaLoggingHandler(logging.Handler):
         # exit hooks work only in main process
         # termination of child processes uses os.exit() and ignore any hooks
         atexit.register(self.at_exit)
-        if self.unhandled_exception is not None:
+
+        # Dont touch sys.excepthook if no logger provided
+        if self.unhandled_exception_logger is not None:
             sys.excepthook = self.unhandled_exception
 
         # multiprocessing support

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ PROJECT_ROOT, _ = os.path.split(__file__)
 NAME = 'kafka-logging-handler'
 EMAILS = 'mbirger@redhat.com, mjahudko@readhat.com, rmonegro@redhat.com'
 AUTHORS = 'Mark Birger, Michaela Jahudkova, Robert Monegro'
-VERSION = '0.2.3'
+VERSION = '0.2.4'
 
 URL = 'https://github.com/redhat-aqe/kafka-logging-handler'
 LICENSE = 'GPLv3'


### PR DESCRIPTION
Hello,
Currently after adding this handler to root logger non handled exceptions might be suppressed and doesnt appear in stderr, which is a bit surprising.